### PR TITLE
Add GitHub Actions MPI CI workflows

### DIFF
--- a/.github/ci/Dockerfile
+++ b/.github/ci/Dockerfile
@@ -1,0 +1,15 @@
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install --yes --no-install-recommends \
+    ca-certificates \
+    cmake \
+    gfortran \
+    libopenmpi-dev \
+    ninja-build \
+    openmpi-bin \
+    python3 \
+    python3-pip \
+  && pip3 install --break-system-packages --no-cache-dir fypp \
+  && rm -rf /var/lib/apt/lists/*

--- a/.github/workflows/build-ci-image.yml
+++ b/.github/workflows/build-ci-image.yml
@@ -1,0 +1,50 @@
+name: Build CI Image
+
+on:
+  workflow_call:
+    outputs:
+      image:
+        description: GHCR image reference for the built CI container
+        value: ${{ jobs.build-ci-image.outputs.image }}
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-ci-image:
+    runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.image.outputs.ref }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Define image reference
+        id: image
+        run: |
+          owner=$(printf '%s' "${GITHUB_REPOSITORY_OWNER}" | tr '[:upper:]' '[:lower:]')
+          echo "ref=ghcr.io/${owner}/index-map-ci:latest" >> "${GITHUB_OUTPUT}"
+          echo "cache=ghcr.io/${owner}/index-map-ci:buildcache" >> "${GITHUB_OUTPUT}"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push CI image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: .github/ci/Dockerfile
+          push: true
+          tags: ${{ steps.image.outputs.ref }}
+          cache-from: type=registry,ref=${{ steps.image.outputs.cache }}
+          cache-to: type=registry,ref=${{ steps.image.outputs.cache }},mode=max

--- a/.github/workflows/ctest-mpi.yml
+++ b/.github/workflows/ctest-mpi.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 2
+          fetch-depth: 0
 
       - name: Define image reference
         id: image

--- a/.github/workflows/ctest-mpi.yml
+++ b/.github/workflows/ctest-mpi.yml
@@ -1,0 +1,96 @@
+name: MPI CTest
+
+on:
+  push:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  resolve-ci-image:
+    runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.image.outputs.ref }}
+      rebuild: ${{ steps.changes.outputs.rebuild }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Define image reference
+        id: image
+        run: |
+          owner=$(printf '%s' "${GITHUB_REPOSITORY_OWNER}" | tr '[:upper:]' '[:lower:]')
+          echo "ref=ghcr.io/${owner}/index-map-ci:latest" >> "${GITHUB_OUTPUT}"
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Detect CI image changes or missing image
+        id: changes
+        run: |
+          image_exists=true
+          if ! docker manifest inspect "${{ steps.image.outputs.ref }}" >/dev/null 2>&1; then
+            image_exists=false
+          fi
+
+          if [ -n "${{ github.event.before }}" ] && [ "${{ github.event.before }}" != "0000000000000000000000000000000000000000" ]; then
+            changed_files=$(git diff --name-only "${{ github.event.before }}" "${{ github.sha }}")
+          else
+            changed_files=$(git diff-tree --no-commit-id --name-only -r "${{ github.sha }}")
+          fi
+
+          if [ "${image_exists}" = false ] || printf '%s\n' "${changed_files}" | grep -Eq '^\.github/ci/|^\.github/workflows/build-ci-image\.yml$'; then
+            echo "rebuild=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "rebuild=false" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Report CI image decision
+        run: |
+          echo "ci_image=${{ steps.image.outputs.ref }}"
+          echo "rebuild=${{ steps.changes.outputs.rebuild }}"
+
+  build-ci-image:
+    needs: resolve-ci-image
+    if: needs.resolve-ci-image.outputs.rebuild == 'true'
+    uses: ./.github/workflows/build-ci-image.yml
+    secrets: inherit
+
+  ctest-mpi:
+    needs:
+      - resolve-ci-image
+      - build-ci-image
+    if: ${{ always() && needs.resolve-ci-image.result == 'success' && (needs.build-ci-image.result == 'success' || needs.build-ci-image.result == 'skipped') }}
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ needs.resolve-ci-image.outputs.rebuild == 'true' && needs.build-ci-image.outputs.image || needs.resolve-ci-image.outputs.image }}
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    env:
+      OMPI_ALLOW_RUN_AS_ROOT: "1"
+      OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: "1"
+      OMPI_MCA_rmaps_base_oversubscribe: "1"
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Configure CMake for MPI build
+        env:
+          FC: mpifort
+        run: cmake -S . -B build -G Ninja -DUSE_CAF=OFF
+
+      - name: Build
+        run: cmake --build build
+
+      - name: Run MPI test suite
+        run: ctest --test-dir build --output-on-failure


### PR DESCRIPTION
## Summary

Add GitHub Actions CI for the MPI build and test path.

## Changes

- add an MPI `ctest` workflow for pushes
- add a reusable GHCR-based CI container build workflow
- add a CI container with OpenMPI, `gfortran`, CMake, Ninja, Python, and `fypp`
- reuse the container across pushes, rebuilding only when CI container inputs change
- log the image reuse decision in the workflow output

## Notes

- tests run in MPI mode only
- OpenMPI oversubscription is enabled for the GitHub runner
