### PR TITLE
Add OpenCoarrays CI support

### DIFF
--- a/.github/ci/Dockerfile
+++ b/.github/ci/Dockerfile
@@ -1,15 +1,43 @@
 FROM ubuntu:24.04
 
 ENV DEBIAN_FRONTEND=noninteractive
+ENV MPICH_VERSION=4.3.1
+ENV OPENCOARRAYS_VERSION=2.10.3
+ENV MPICH_PREFIX=/opt/mpich/${MPICH_VERSION}
+ENV OPENCOARRAYS_PREFIX=/opt/opencoarrays/${OPENCOARRAYS_VERSION}
+ENV PATH=${OPENCOARRAYS_PREFIX}/bin:${MPICH_PREFIX}/bin:${PATH}
+ENV LD_LIBRARY_PATH=${OPENCOARRAYS_PREFIX}/lib64:${MPICH_PREFIX}/lib:${LD_LIBRARY_PATH:-}
 
 RUN apt-get update && apt-get install --yes --no-install-recommends \
+    build-essential \
     ca-certificates \
     cmake \
     gfortran \
-    libopenmpi-dev \
+    git \
     ninja-build \
-    openmpi-bin \
     python3 \
     python3-pip \
+    wget \
+  && wget -q https://www.mpich.org/static/downloads/${MPICH_VERSION}/mpich-${MPICH_VERSION}.tar.gz -O /tmp/mpich.tar.gz \
+  && tar -C /tmp -xf /tmp/mpich.tar.gz \
+  && cd /tmp/mpich-${MPICH_VERSION} \
+  && ./configure \
+       FCFLAGS="-fallow-argument-mismatch" \
+       FFLAGS="-fallow-argument-mismatch" \
+       --prefix="${MPICH_PREFIX}" \
+  && make -j"$(nproc)" FCFLAGS="-fallow-argument-mismatch" FFLAGS="-fallow-argument-mismatch" \
+  && make install \
+  && git clone --branch "${OPENCOARRAYS_VERSION}" --depth 1 https://github.com/sourceryinstitute/OpenCoarrays.git /tmp/OpenCoarrays \
+  && cmake -S /tmp/OpenCoarrays -B /tmp/OpenCoarrays/build \
+       -DCMAKE_BUILD_TYPE=Release \
+       -DCMAKE_C_COMPILER=gcc \
+       -DCMAKE_Fortran_COMPILER=gfortran \
+       -DCMAKE_INSTALL_PREFIX="${OPENCOARRAYS_PREFIX}" \
+       -DMPI_C_COMPILER="${MPICH_PREFIX}/bin/mpicc" \
+       -DMPI_Fortran_COMPILER="${MPICH_PREFIX}/bin/mpifort" \
+  && cmake --build /tmp/OpenCoarrays/build --parallel \
+  && cmake --install /tmp/OpenCoarrays/build \
+  && cd / \
+  && rm -rf /tmp/OpenCoarrays /tmp/mpich-${MPICH_VERSION} /tmp/mpich.tar.gz \
   && pip3 install --break-system-packages --no-cache-dir fypp \
   && rm -rf /var/lib/apt/lists/*

--- a/.github/workflows/ctest-mpi.yml
+++ b/.github/workflows/ctest-mpi.yml
@@ -1,4 +1,4 @@
-name: MPI CTest
+name: CTest
 
 on:
   push:
@@ -78,10 +78,6 @@ jobs:
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-    env:
-      OMPI_ALLOW_RUN_AS_ROOT: "1"
-      OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: "1"
-      OMPI_MCA_rmaps_base_oversubscribe: "1"
 
     steps:
       - name: Check out repository
@@ -97,3 +93,30 @@ jobs:
 
       - name: Run MPI test suite
         run: ctest --test-dir build --output-on-failure
+
+  ctest-caf:
+    needs:
+      - resolve-ci-image
+      - build-ci-image
+    if: ${{ always() && needs.resolve-ci-image.result == 'success' && (needs.build-ci-image.result == 'success' || needs.build-ci-image.result == 'skipped') }}
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ needs.resolve-ci-image.outputs.rebuild == 'true' && needs.build-ci-image.outputs.image || needs.resolve-ci-image.outputs.image }}
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Configure CMake for CAF build
+        env:
+          FC: caf
+        run: cmake -S . -B build-caf -G Ninja -DUSE_CAF=ON
+
+      - name: Build CAF
+        run: cmake --build build-caf
+
+      - name: Run CAF test suite
+        run: ctest --test-dir build-caf --output-on-failure

--- a/src/caf/index_map_type-gather_offp_impl.F90
+++ b/src/caf/index_map_type-gather_offp_impl.F90
@@ -67,6 +67,45 @@ contains
 #include "gath_3.inc"
   end subroutine
 
+!!!! I8 DATA !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+  module subroutine gath1_i8_1(this, local_data)
+    class(index_map), intent(in) :: this
+    integer(i8), intent(inout) :: local_data(:)
+    call gath2_i8_1(this, local_data(:this%onp_size), local_data(this%onp_size+1:))
+  end subroutine
+
+  module subroutine gath2_i8_1(this, onp_data, offp_data)
+#define __DATA_TYPE__ integer(i8)
+#ifdef __GFORTRAN__
+#include "gath_1_alt.inc"
+#else
+#include "gath_1.inc"
+#endif
+  end subroutine
+
+  module subroutine gath1_i8_2(this, local_data)
+    class(index_map), intent(in) :: this
+    integer(i8), intent(inout) :: local_data(:,:)
+    call gath2_i8_2(this, local_data(:,:this%onp_size), local_data(:,this%onp_size+1:))
+  end subroutine
+
+  module subroutine gath2_i8_2(this, onp_data, offp_data)
+#define __DATA_TYPE__ integer(i8)
+#include "gath_2.inc"
+  end subroutine
+
+  module subroutine gath1_i8_3(this, local_data)
+    class(index_map), intent(in) :: this
+    integer(i8), intent(inout) :: local_data(:,:,:)
+    call gath2_i8_3(this, local_data(:,:,:this%onp_size), local_data(:,:,this%onp_size+1:))
+  end subroutine
+
+  module subroutine gath2_i8_3(this, onp_data, offp_data)
+#define __DATA_TYPE__ integer(i8)
+#include "gath_3.inc"
+  end subroutine
+
 !!!! R4 DATA !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
   module subroutine gath1_r4_1(this, local_data)

--- a/src/caf/index_map_type.F90
+++ b/src/caf/index_map_type.F90
@@ -56,6 +56,7 @@ module index_map_type
     procedure :: global_index
     generic :: gather_offp => &
         gath1_i4_1, gath2_i4_1, gath1_i4_2, gath2_i4_2, gath1_i4_3, gath2_i4_3, &
+        gath1_i8_1, gath2_i8_1, gath1_i8_2, gath2_i8_2, gath1_i8_3, gath2_i8_3, &
         gath1_r4_1, gath2_r4_1, gath1_r4_2, gath2_r4_2, gath1_r4_3, gath2_r4_3, &
         gath1_r8_1, gath2_r8_1, gath1_r8_2, gath2_r8_2, gath1_r8_3, gath2_r8_3, &
         gath1_c4_1, gath2_c4_1, gath1_c4_2, gath2_c4_2, gath1_c4_3, gath2_c4_3, &
@@ -90,6 +91,7 @@ module index_map_type
     procedure, private :: init_dist, init_root, init_dist_offp, init_root_offp, init_ragged
     procedure, private :: &
         gath1_i4_1, gath2_i4_1, gath1_i4_2, gath2_i4_2, gath1_i4_3, gath2_i4_3, &
+        gath1_i8_1, gath2_i8_1, gath1_i8_2, gath2_i8_2, gath1_i8_3, gath2_i8_3, &
         gath1_r4_1, gath2_r4_1, gath1_r4_2, gath2_r4_2, gath1_r4_3, gath2_r4_3, &
         gath1_r8_1, gath2_r8_1, gath1_r8_2, gath2_r8_2, gath1_r8_3, gath2_r8_3, &
         gath1_c4_1, gath2_c4_1, gath1_c4_2, gath2_c4_2, gath1_c4_3, gath2_c4_3, &
@@ -129,6 +131,10 @@ module index_map_type
       class(index_map), intent(in) :: this
       integer(i4), intent(inout) :: local_data(:)
     end subroutine
+    module subroutine gath1_i8_1(this, local_data)
+      class(index_map), intent(in) :: this
+      integer(i8), intent(inout) :: local_data(:)
+    end subroutine
     module subroutine gath1_r4_1(this, local_data)
       class(index_map), intent(in) :: this
       real(r4), intent(inout) :: local_data(:)
@@ -154,6 +160,11 @@ module index_map_type
       class(index_map), intent(in) :: this
       integer(i4), intent(in) :: onp_data(:)
       integer(i4), intent(inout), target :: offp_data(:)
+    end subroutine
+    module subroutine gath2_i8_1(this, onp_data, offp_data)
+      class(index_map), intent(in) :: this
+      integer(i8), intent(in) :: onp_data(:)
+      integer(i8), intent(inout), target :: offp_data(:)
     end subroutine
     module subroutine gath2_r4_1(this, onp_data, offp_data)
       class(index_map), intent(in) :: this
@@ -185,6 +196,10 @@ module index_map_type
       class(index_map), intent(in) :: this
       integer(i4), intent(inout) :: local_data(:,:)
     end subroutine
+    module subroutine gath1_i8_2(this, local_data)
+      class(index_map), intent(in) :: this
+      integer(i8), intent(inout) :: local_data(:,:)
+    end subroutine
     module subroutine gath1_r4_2(this, local_data)
       class(index_map), intent(in) :: this
       real(r4), intent(inout) :: local_data(:,:)
@@ -210,6 +225,11 @@ module index_map_type
       class(index_map), intent(in) :: this
       integer(i4), intent(in) :: onp_data(:,:)
       integer(i4), intent(inout), target :: offp_data(:,:)
+    end subroutine
+    module subroutine gath2_i8_2(this, onp_data, offp_data)
+      class(index_map), intent(in) :: this
+      integer(i8), intent(in) :: onp_data(:,:)
+      integer(i8), intent(inout), target :: offp_data(:,:)
     end subroutine
     module subroutine gath2_r4_2(this, onp_data, offp_data)
       class(index_map), intent(in) :: this
@@ -241,6 +261,10 @@ module index_map_type
       class(index_map), intent(in) :: this
       integer(i4), intent(inout) :: local_data(:,:,:)
     end subroutine
+    module subroutine gath1_i8_3(this, local_data)
+      class(index_map), intent(in) :: this
+      integer(i8), intent(inout) :: local_data(:,:,:)
+    end subroutine
     module subroutine gath1_r4_3(this, local_data)
       class(index_map), intent(in) :: this
       real(r4), intent(inout) :: local_data(:,:,:)
@@ -266,6 +290,11 @@ module index_map_type
       class(index_map), intent(in) :: this
       integer(i4), intent(in) :: onp_data(:,:,:)
       integer(i4), intent(inout), target :: offp_data(:,:,:)
+    end subroutine
+    module subroutine gath2_i8_3(this, onp_data, offp_data)
+      class(index_map), intent(in) :: this
+      integer(i8), intent(in) :: onp_data(:,:,:)
+      integer(i8), intent(inout), target :: offp_data(:,:,:)
     end subroutine
     module subroutine gath2_r4_3(this, onp_data, offp_data)
       class(index_map), intent(in) :: this


### PR DESCRIPTION
## Summary
- add int64 CAF gather overloads
- build a shared CI image with MPICH 4.3.1 and OpenCoarrays 2.10.3
- run both MPI and CAF test jobs in that shared image

## Testing
- GitHub Actions MPI CI workflow passed for both MPI and CAF jobs