### PR TITLE
Replace source MIT headers with SPDX notices

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright (c) 2022-2024 Neil N. Carlson
+Copyright (c) 2022-2026 Neil N. Carlson
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/example/disk-fem-parallel.F90
+++ b/example/disk-fem-parallel.F90
@@ -16,25 +16,8 @@
 !!
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !!
-!! Copyright 2022 Neil N. Carlson <neil.n.carlson@gmail.com>
-!!
-!! Permission is hereby granted, free of charge, to any person obtaining a
-!! copy of this software and associated documentation files (the "Software"),
-!! to deal in the Software without restriction, including without limitation
-!! the rights to use, copy, modify, merge, publish, distribute, sublicense,
-!! and/or sell copies of the Software, and to permit persons to whom the
-!! Software is furnished to do so, subject to the following conditions:
-!!
-!! The above copyright notice and this permission notice shall be included
-!! in all copies or substantial portions of the Software.
-!!
-!! THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-!! IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-!! FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
-!! THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-!! LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-!! FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-!! DEALINGS IN THE SOFTWARE.
+!! Copyright (c) 2022, 2026 Neil N. Carlson <neil.n.carlson@gmail.com>
+!! SPDX-License-Identifier: MIT
 !!
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 

--- a/example/disk-fem-serial.F90
+++ b/example/disk-fem-serial.F90
@@ -13,25 +13,8 @@
 !!
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !!
-!! Copyright 2022 Neil N. Carlson <neil.n.carlson@gmail.com>
-!!
-!! Permission is hereby granted, free of charge, to any person obtaining a
-!! copy of this software and associated documentation files (the "Software"),
-!! to deal in the Software without restriction, including without limitation
-!! the rights to use, copy, modify, merge, publish, distribute, sublicense,
-!! and/or sell copies of the Software, and to permit persons to whom the
-!! Software is furnished to do so, subject to the following conditions:
-!!
-!! The above copyright notice and this permission notice shall be included
-!! in all copies or substantial portions of the Software.
-!!
-!! THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-!! IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-!! FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
-!! THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-!! LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-!! FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-!! DEALINGS IN THE SOFTWARE.
+!! Copyright (c) 2022, 2026 Neil N. Carlson <neil.n.carlson@gmail.com>
+!! SPDX-License-Identifier: MIT
 !!
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 

--- a/example/disk-fv-parallel.F90
+++ b/example/disk-fv-parallel.F90
@@ -15,25 +15,8 @@
 !!
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !!
-!! Copyright 2022 Neil N. Carlson <neil.n.carlson@gmail.com>
-!!
-!! Permission is hereby granted, free of charge, to any person obtaining a
-!! copy of this software and associated documentation files (the "Software"),
-!! to deal in the Software without restriction, including without limitation
-!! the rights to use, copy, modify, merge, publish, distribute, sublicense,
-!! and/or sell copies of the Software, and to permit persons to whom the
-!! Software is furnished to do so, subject to the following conditions:
-!!
-!! The above copyright notice and this permission notice shall be included
-!! in all copies or substantial portions of the Software.
-!!
-!! THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-!! IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-!! FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
-!! THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-!! LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-!! FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-!! DEALINGS IN THE SOFTWARE.
+!! Copyright (c) 2022, 2026 Neil N. Carlson <neil.n.carlson@gmail.com>
+!! SPDX-License-Identifier: MIT
 !!
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 

--- a/example/disk-fv-serial.F90
+++ b/example/disk-fv-serial.F90
@@ -11,25 +11,8 @@
 !!
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !!
-!! Copyright 2022 Neil N. Carlson <neil.n.carlson@gmail.com>
-!!
-!! Permission is hereby granted, free of charge, to any person obtaining a
-!! copy of this software and associated documentation files (the "Software"),
-!! to deal in the Software without restriction, including without limitation
-!! the rights to use, copy, modify, merge, publish, distribute, sublicense,
-!! and/or sell copies of the Software, and to permit persons to whom the
-!! Software is furnished to do so, subject to the following conditions:
-!!
-!! The above copyright notice and this permission notice shall be included
-!! in all copies or substantial portions of the Software.
-!!
-!! THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-!! IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-!! FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
-!! THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-!! LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-!! FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-!! DEALINGS IN THE SOFTWARE.
+!! Copyright (c) 2022, 2026 Neil N. Carlson <neil.n.carlson@gmail.com>
+!! SPDX-License-Identifier: MIT
 !!
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 

--- a/example/redistribute.F90
+++ b/example/redistribute.F90
@@ -7,25 +7,8 @@
 !!
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !!
-!! Copyright 2022 Neil N. Carlson <neil.n.carlson@gmail.com>
-!!
-!! Permission is hereby granted, free of charge, to any person obtaining a
-!! copy of this software and associated documentation files (the "Software"),
-!! to deal in the Software without restriction, including without limitation
-!! the rights to use, copy, modify, merge, publish, distribute, sublicense,
-!! and/or sell copies of the Software, and to permit persons to whom the
-!! Software is furnished to do so, subject to the following conditions:
-!!
-!! The above copyright notice and this permission notice shall be included
-!! in all copies or substantial portions of the Software.
-!!
-!! THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-!! IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-!! FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
-!! THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-!! LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-!! FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-!! DEALINGS IN THE SOFTWARE.
+!! Copyright (c) 2022, 2026 Neil N. Carlson <neil.n.carlson@gmail.com>
+!! SPDX-License-Identifier: MIT
 !!
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 

--- a/src/caf/coarray_collectives.F90
+++ b/src/caf/coarray_collectives.F90
@@ -1,24 +1,7 @@
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !!
-!! Copyright (c) 2022  Neil N. Carlson
-!!
-!! Permission is hereby granted, free of charge, to any person obtaining a
-!! copy of this software and associated documentation files (the "Software"),
-!! to deal in the Software without restriction, including without limitation
-!! the rights to use, copy, modify, merge, publish, distribute, sublicense,
-!! and/or sell copies of the Software, and to permit persons to whom the
-!! Software is furnished to do so, subject to the following conditions:
-!!
-!! The above copyright notice and this permission notice shall be included
-!! in all copies or substantial portions of the Software.
-!!
-!! THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-!! IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-!! FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
-!! THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-!! LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-!! FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-!! DEALINGS IN THE SOFTWARE.
+!! Copyright (c) 2022, 2026  Neil N. Carlson
+!! SPDX-License-Identifier: MIT
 !!
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 

--- a/src/caf/index_map_type-collate_impl.F90.fypp
+++ b/src/caf/index_map_type-collate_impl.F90.fypp
@@ -1,24 +1,7 @@
 !! Implementation of INDEX_MAP Collate Subroutines
 !!
-!! Copyright 2022 Neil N. Carlson <neil.n.carlson@gmail.com>
-!!
-!! Permission is hereby granted, free of charge, to any person obtaining a
-!! copy of this software and associated documentation files (the "Software"),
-!! to deal in the Software without restriction, including without limitation
-!! the rights to use, copy, modify, merge, publish, distribute, sublicense,
-!! and/or sell copies of the Software, and to permit persons to whom the
-!! Software is furnished to do so, subject to the following conditions:
-!!
-!! The above copyright notice and this permission notice shall be included
-!! in all copies or substantial portions of the Software.
-!!
-!! THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-!! IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-!! FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
-!! THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-!! LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-!! FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-!! DEALINGS IN THE SOFTWARE.
+!! Copyright (c) 2022, 2026 Neil N. Carlson <neil.n.carlson@gmail.com>
+!! SPDX-License-Identifier: MIT
 !!
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 

--- a/src/caf/index_map_type-distribute_impl.F90.fypp
+++ b/src/caf/index_map_type-distribute_impl.F90.fypp
@@ -1,24 +1,7 @@
 !! Implementation of INDEX_MAP DISTRIBUTE Subroutines
 !!
-!! Copyright 2022 Neil N. Carlson <neil.n.carlson@gmail.com>
-!!
-!! Permission is hereby granted, free of charge, to any person obtaining a
-!! copy of this software and associated documentation files (the "Software"),
-!! to deal in the Software without restriction, including without limitation
-!! the rights to use, copy, modify, merge, publish, distribute, sublicense,
-!! and/or sell copies of the Software, and to permit persons to whom the
-!! Software is furnished to do so, subject to the following conditions:
-!!
-!! The above copyright notice and this permission notice shall be included
-!! in all copies or substantial portions of the Software.
-!!
-!! THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-!! IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-!! FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
-!! THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-!! LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-!! FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-!! DEALINGS IN THE SOFTWARE.
+!! Copyright (c) 2022, 2026 Neil N. Carlson <neil.n.carlson@gmail.com>
+!! SPDX-License-Identifier: MIT
 !!
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 

--- a/src/caf/index_map_type-gather_offp_impl.F90.fypp
+++ b/src/caf/index_map_type-gather_offp_impl.F90.fypp
@@ -1,24 +1,7 @@
 !! Implementation of INDEX_MAP GATHER_OFFP Procedures
 !!
-!! Copyright 2022 Neil N. Carlson <neil.n.carlson@gmail.com>
-!!
-!! Permission is hereby granted, free of charge, to any person obtaining a
-!! copy of this software and associated documentation files (the "Software"),
-!! to deal in the Software without restriction, including without limitation
-!! the rights to use, copy, modify, merge, publish, distribute, sublicense,
-!! and/or sell copies of the Software, and to permit persons to whom the
-!! Software is furnished to do so, subject to the following conditions:
-!!
-!! The above copyright notice and this permission notice shall be included
-!! in all copies or substantial portions of the Software.
-!!
-!! THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-!! IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-!! FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
-!! THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-!! LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-!! FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-!! DEALINGS IN THE SOFTWARE.
+!! Copyright (c) 2022, 2026 Neil N. Carlson <neil.n.carlson@gmail.com>
+!! SPDX-License-Identifier: MIT
 !!
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 

--- a/src/caf/index_map_type-localize_impl.F90.fypp
+++ b/src/caf/index_map_type-localize_impl.F90.fypp
@@ -1,24 +1,7 @@
 !! Implementation of INDEX_MAP LOCALIZE_INDEX_ARRAY Subroutines
 !!
-!! Copyright 2022 Neil N. Carlson <neil.n.carlson@gmail.com>
-!!
-!! Permission is hereby granted, free of charge, to any person obtaining a
-!! copy of this software and associated documentation files (the "Software"),
-!! to deal in the Software without restriction, including without limitation
-!! the rights to use, copy, modify, merge, publish, distribute, sublicense,
-!! and/or sell copies of the Software, and to permit persons to whom the
-!! Software is furnished to do so, subject to the following conditions:
-!!
-!! The above copyright notice and this permission notice shall be included
-!! in all copies or substantial portions of the Software.
-!!
-!! THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-!! IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-!! FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
-!! THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-!! LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-!! FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-!! DEALINGS IN THE SOFTWARE.
+!! Copyright (c) 2022, 2026 Neil N. Carlson <neil.n.carlson@gmail.com>
+!! SPDX-License-Identifier: MIT
 !!
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 

--- a/src/caf/index_map_type-scatter_offp_impl.F90.fypp
+++ b/src/caf/index_map_type-scatter_offp_impl.F90.fypp
@@ -1,24 +1,7 @@
 !! Implementation of INDEX_MAP SCATTER_OFFP Procedures
 !!
-!! Copyright 2022 Neil N. Carlson <neil.n.carlson@gmail.com>
-!!
-!! Permission is hereby granted, free of charge, to any person obtaining a
-!! copy of this software and associated documentation files (the "Software"),
-!! to deal in the Software without restriction, including without limitation
-!! the rights to use, copy, modify, merge, publish, distribute, sublicense,
-!! and/or sell copies of the Software, and to permit persons to whom the
-!! Software is furnished to do so, subject to the following conditions:
-!!
-!! The above copyright notice and this permission notice shall be included
-!! in all copies or substantial portions of the Software.
-!!
-!! THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-!! IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-!! FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
-!! THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-!! LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-!! FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-!! DEALINGS IN THE SOFTWARE.
+!! Copyright (c) 2022, 2026 Neil N. Carlson <neil.n.carlson@gmail.com>
+!! SPDX-License-Identifier: MIT
 !!
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 

--- a/src/caf/index_map_type.F90.fypp
+++ b/src/caf/index_map_type.F90.fypp
@@ -9,25 +9,8 @@
 !! additional procedures for distributing and localizing serial indirect
 !! indexing arrays.
 !!
-!! Copyright (c) 2022  Neil N. Carlson
-!!
-!! Permission is hereby granted, free of charge, to any person obtaining a
-!! copy of this software and associated documentation files (the "Software"),
-!! to deal in the Software without restriction, including without limitation
-!! the rights to use, copy, modify, merge, publish, distribute, sublicense,
-!! and/or sell copies of the Software, and to permit persons to whom the
-!! Software is furnished to do so, subject to the following conditions:
-!!
-!! The above copyright notice and this permission notice shall be included
-!! in all copies or substantial portions of the Software.
-!!
-!! THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-!! IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-!! FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
-!! THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-!! LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-!! FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-!! DEALINGS IN THE SOFTWARE.
+!! Copyright (c) 2022, 2026  Neil N. Carlson
+!! SPDX-License-Identifier: MIT
 !!
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 

--- a/src/mpi/index_map_type-collate_impl.F90.fypp
+++ b/src/mpi/index_map_type-collate_impl.F90.fypp
@@ -1,24 +1,7 @@
 !! Implementation of INDEX_MAP Collate Subroutines
 !!
-!! Copyright 2022, 2026 Neil N. Carlson <neil.n.carlson@gmail.com>
-!!
-!! Permission is hereby granted, free of charge, to any person obtaining a
-!! copy of this software and associated documentation files (the "Software"),
-!! to deal in the Software without restriction, including without limitation
-!! the rights to use, copy, modify, merge, publish, distribute, sublicense,
-!! and/or sell copies of the Software, and to permit persons to whom the
-!! Software is furnished to do so, subject to the following conditions:
-!!
-!! The above copyright notice and this permission notice shall be included
-!! in all copies or substantial portions of the Software.
-!!
-!! THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-!! IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-!! FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
-!! THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-!! LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-!! FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-!! DEALINGS IN THE SOFTWARE.
+!! Copyright (c) 2022, 2026 Neil N. Carlson <neil.n.carlson@gmail.com>
+!! SPDX-License-Identifier: MIT
 !!
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 

--- a/src/mpi/index_map_type-distribute_impl.F90.fypp
+++ b/src/mpi/index_map_type-distribute_impl.F90.fypp
@@ -1,24 +1,7 @@
 !! Implementation of INDEX_MAP DISTRIBUTE Subroutines
 !!
-!! Copyright 2022, 2026 Neil N. Carlson <neil.n.carlson@gmail.com>
-!!
-!! Permission is hereby granted, free of charge, to any person obtaining a
-!! copy of this software and associated documentation files (the "Software"),
-!! to deal in the Software without restriction, including without limitation
-!! the rights to use, copy, modify, merge, publish, distribute, sublicense,
-!! and/or sell copies of the Software, and to permit persons to whom the
-!! Software is furnished to do so, subject to the following conditions:
-!!
-!! The above copyright notice and this permission notice shall be included
-!! in all copies or substantial portions of the Software.
-!!
-!! THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-!! IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-!! FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
-!! THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-!! LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-!! FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-!! DEALINGS IN THE SOFTWARE.
+!! Copyright (c) 2022, 2026 Neil N. Carlson <neil.n.carlson@gmail.com>
+!! SPDX-License-Identifier: MIT
 !!
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 

--- a/src/mpi/index_map_type-gather_offp_impl.F90.fypp
+++ b/src/mpi/index_map_type-gather_offp_impl.F90.fypp
@@ -1,24 +1,7 @@
 !! Implementation of INDEX_MAP GATHER_OFFP Procedures
 !!
-!! Copyright 2022, 2026 Neil N. Carlson <neil.n.carlson@gmail.com>
-!!
-!! Permission is hereby granted, free of charge, to any person obtaining a
-!! copy of this software and associated documentation files (the "Software"),
-!! to deal in the Software without restriction, including without limitation
-!! the rights to use, copy, modify, merge, publish, distribute, sublicense,
-!! and/or sell copies of the Software, and to permit persons to whom the
-!! Software is furnished to do so, subject to the following conditions:
-!!
-!! The above copyright notice and this permission notice shall be included
-!! in all copies or substantial portions of the Software.
-!!
-!! THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-!! IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-!! FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
-!! THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-!! LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-!! FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-!! DEALINGS IN THE SOFTWARE.
+!! Copyright (c) 2022, 2026 Neil N. Carlson <neil.n.carlson@gmail.com>
+!! SPDX-License-Identifier: MIT
 !!
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 

--- a/src/mpi/index_map_type-localize_impl.F90.fypp
+++ b/src/mpi/index_map_type-localize_impl.F90.fypp
@@ -1,24 +1,7 @@
 !! Implementation of INDEX_MAP LOCALIZE_INDEX_ARRAY Subroutines
 !!
-!! Copyright 2022, 2026 Neil N. Carlson <neil.n.carlson@gmail.com>
-!!
-!! Permission is hereby granted, free of charge, to any person obtaining a
-!! copy of this software and associated documentation files (the "Software"),
-!! to deal in the Software without restriction, including without limitation
-!! the rights to use, copy, modify, merge, publish, distribute, sublicense,
-!! and/or sell copies of the Software, and to permit persons to whom the
-!! Software is furnished to do so, subject to the following conditions:
-!!
-!! The above copyright notice and this permission notice shall be included
-!! in all copies or substantial portions of the Software.
-!!
-!! THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-!! IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-!! FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
-!! THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-!! LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-!! FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-!! DEALINGS IN THE SOFTWARE.
+!! Copyright (c) 2022, 2026 Neil N. Carlson <neil.n.carlson@gmail.com>
+!! SPDX-License-Identifier: MIT
 !!
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 

--- a/src/mpi/index_map_type-scatter_offp_impl.F90.fypp
+++ b/src/mpi/index_map_type-scatter_offp_impl.F90.fypp
@@ -1,24 +1,7 @@
 !! Implementation of INDEX_MAP SCATTER_OFFP Procedures
 !!
-!! Copyright 2022, 2026 Neil N. Carlson <neil.n.carlson@gmail.com>
-!!
-!! Permission is hereby granted, free of charge, to any person obtaining a
-!! copy of this software and associated documentation files (the "Software"),
-!! to deal in the Software without restriction, including without limitation
-!! the rights to use, copy, modify, merge, publish, distribute, sublicense,
-!! and/or sell copies of the Software, and to permit persons to whom the
-!! Software is furnished to do so, subject to the following conditions:
-!!
-!! The above copyright notice and this permission notice shall be included
-!! in all copies or substantial portions of the Software.
-!!
-!! THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-!! IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-!! FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
-!! THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-!! LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-!! FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-!! DEALINGS IN THE SOFTWARE.
+!! Copyright (c) 2022, 2026 Neil N. Carlson <neil.n.carlson@gmail.com>
+!! SPDX-License-Identifier: MIT
 !!
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 

--- a/src/mpi/index_map_type.F90.fypp
+++ b/src/mpi/index_map_type.F90.fypp
@@ -10,24 +10,7 @@
 !! indexing arrays.
 !!
 !! Copyright (c) 2022, 2026  Neil N. Carlson
-!!
-!! Permission is hereby granted, free of charge, to any person obtaining a
-!! copy of this software and associated documentation files (the "Software"),
-!! to deal in the Software without restriction, including without limitation
-!! the rights to use, copy, modify, merge, publish, distribute, sublicense,
-!! and/or sell copies of the Software, and to permit persons to whom the
-!! Software is furnished to do so, subject to the following conditions:
-!!
-!! The above copyright notice and this permission notice shall be included
-!! in all copies or substantial portions of the Software.
-!!
-!! THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-!! IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-!! FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
-!! THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-!! LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-!! FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-!! DEALINGS IN THE SOFTWARE.
+!! SPDX-License-Identifier: MIT
 !!
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 

--- a/test/collate_test.F90
+++ b/test/collate_test.F90
@@ -1,24 +1,7 @@
 !! Unit Tests for INDEX_MAP Collate Procedures
 !!
-!! Copyright 2022 Neil N. Carlson <neil.n.carlson@gmail.com>
-!!
-!! Permission is hereby granted, free of charge, to any person obtaining a
-!! copy of this software and associated documentation files (the "Software"),
-!! to deal in the Software without restriction, including without limitation
-!! the rights to use, copy, modify, merge, publish, distribute, sublicense,
-!! and/or sell copies of the Software, and to permit persons to whom the
-!! Software is furnished to do so, subject to the following conditions:
-!!
-!! The above copyright notice and this permission notice shall be included
-!! in all copies or substantial portions of the Software.
-!!
-!! THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-!! IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-!! FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
-!! THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-!! LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-!! FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-!! DEALINGS IN THE SOFTWARE.
+!! Copyright (c) 2022, 2026 Neil N. Carlson <neil.n.carlson@gmail.com>
+!! SPDX-License-Identifier: MIT
 !!
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 

--- a/test/distribute_test.F90
+++ b/test/distribute_test.F90
@@ -1,24 +1,7 @@
 !! Unit Tests for INDEX_MAP Distribute Procedures
 !!
-!! Copyright 2022 Neil N. Carlson <neil.n.carlson@gmail.com>
-!!
-!! Permission is hereby granted, free of charge, to any person obtaining a
-!! copy of this software and associated documentation files (the "Software"),
-!! to deal in the Software without restriction, including without limitation
-!! the rights to use, copy, modify, merge, publish, distribute, sublicense,
-!! and/or sell copies of the Software, and to permit persons to whom the
-!! Software is furnished to do so, subject to the following conditions:
-!!
-!! The above copyright notice and this permission notice shall be included
-!! in all copies or substantial portions of the Software.
-!!
-!! THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-!! IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-!! FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
-!! THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-!! LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-!! FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-!! DEALINGS IN THE SOFTWARE.
+!! Copyright (c) 2022, 2026 Neil N. Carlson <neil.n.carlson@gmail.com>
+!! SPDX-License-Identifier: MIT
 !!
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 

--- a/test/gather_test.F90
+++ b/test/gather_test.F90
@@ -1,24 +1,7 @@
 !! Unit Tests for INDEX_MAP Off-Process Gather Procedures
 !!
-!! Copyright 2022, 2026 Neil N. Carlson <neil.n.carlson@gmail.com>
-!!
-!! Permission is hereby granted, free of charge, to any person obtaining a
-!! copy of this software and associated documentation files (the "Software"),
-!! to deal in the Software without restriction, including without limitation
-!! the rights to use, copy, modify, merge, publish, distribute, sublicense,
-!! and/or sell copies of the Software, and to permit persons to whom the
-!! Software is furnished to do so, subject to the following conditions:
-!!
-!! The above copyright notice and this permission notice shall be included
-!! in all copies or substantial portions of the Software.
-!!
-!! THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-!! IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-!! FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
-!! THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-!! LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-!! FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-!! DEALINGS IN THE SOFTWARE.
+!! Copyright (c) 2022, 2026 Neil N. Carlson <neil.n.carlson@gmail.com>
+!! SPDX-License-Identifier: MIT
 !!
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 

--- a/test/localize_test.F90
+++ b/test/localize_test.F90
@@ -1,24 +1,7 @@
 !! Unit Tests for INDEX_MAP Localize Procedures
 !!
-!! Copyright 2022 Neil N. Carlson <neil.n.carlson@gmail.com>
-!!
-!! Permission is hereby granted, free of charge, to any person obtaining a
-!! copy of this software and associated documentation files (the "Software"),
-!! to deal in the Software without restriction, including without limitation
-!! the rights to use, copy, modify, merge, publish, distribute, sublicense,
-!! and/or sell copies of the Software, and to permit persons to whom the
-!! Software is furnished to do so, subject to the following conditions:
-!!
-!! The above copyright notice and this permission notice shall be included
-!! in all copies or substantial portions of the Software.
-!!
-!! THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-!! IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-!! FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
-!! THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-!! LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-!! FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-!! DEALINGS IN THE SOFTWARE.
+!! Copyright (c) 2022, 2026 Neil N. Carlson <neil.n.carlson@gmail.com>
+!! SPDX-License-Identifier: MIT
 !!
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 

--- a/test/scatter_test.F90
+++ b/test/scatter_test.F90
@@ -1,24 +1,7 @@
 !! Unit Tests for INDEX_MAP Off-Process Scatter Procedures
 !!
-!! Copyright 2022 Neil N. Carlson <neil.n.carlson@gmail.com>
-!!
-!! Permission is hereby granted, free of charge, to any person obtaining a
-!! copy of this software and associated documentation files (the "Software"),
-!! to deal in the Software without restriction, including without limitation
-!! the rights to use, copy, modify, merge, publish, distribute, sublicense,
-!! and/or sell copies of the Software, and to permit persons to whom the
-!! Software is furnished to do so, subject to the following conditions:
-!!
-!! The above copyright notice and this permission notice shall be included
-!! in all copies or substantial portions of the Software.
-!!
-!! THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-!! IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-!! FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
-!! THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-!! LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-!! FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-!! DEALINGS IN THE SOFTWARE.
+!! Copyright (c) 2022, 2026 Neil N. Carlson <neil.n.carlson@gmail.com>
+!! SPDX-License-Identifier: MIT
 !!
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 


### PR DESCRIPTION
## Summary
- replace long MIT license headers in source, test, and example files with short SPDX notices
- update copyright notices in those files to include 2026 where needed
- keep the full MIT text in LICENSE.md and update its year range to 2022-2026