### PR TITLE
Add int64 scatter_offp support

### DIFF
--- a/src/caf/index_map_type-scatter_offp_impl.F90.fypp
+++ b/src/caf/index_map_type-scatter_offp_impl.F90.fypp
@@ -11,11 +11,13 @@ submodule(index_map_type) scatter_impl
 implicit none
 
 #:set sum_types = [ ('i4', 'integer(i4)', 'onp_data(m) + offp[i]%data(offset+k)'), &
+                  & ('i8', 'integer(i8)', 'onp_data(m) + offp[i]%data(offset+k)'), &
                   & ('r4', 'real(r4)', 'onp_data(m) + offp[i]%data(offset+k)'), &
                   & ('r8', 'real(r8)', 'onp_data(m) + offp[i]%data(offset+k)'), &
                   & ('c4', 'complex(r4)', 'onp_data(m) + offp[i]%data(offset+k)'), &
                   & ('c8', 'complex(r8)', 'onp_data(m) + offp[i]%data(offset+k)') ]
 #:set minmax_types = [ ('i4', 'integer(i4)'), &
+                     & ('i8', 'integer(i8)'), &
                      & ('r4', 'real(r4)'), &
                      & ('r8', 'real(r8)') ]
 

--- a/src/caf/index_map_type.F90.fypp
+++ b/src/caf/index_map_type.F90.fypp
@@ -37,11 +37,13 @@ $:'(' + ':' + ',:' * (rank - 1) + ')'
 #:set dist_ranks = range(1, 4)
 #:set localize_serial_ranks = range(1, 3)
 #:set scat_sum_types = [ ('i4', 'integer(i4)'), &
+                      & ('i8', 'integer(i8)'), &
                       & ('r4', 'real(r4)'), &
                       & ('r8', 'real(r8)'), &
                       & ('c4', 'complex(r4)'), &
                       & ('c8', 'complex(r8)') ]
 #:set scat_minmax_types = [ ('i4', 'integer(i4)'), &
+                         & ('i8', 'integer(i8)'), &
                          & ('r4', 'real(r4)'), &
                          & ('r8', 'real(r8)') ]
 

--- a/src/mpi/index_map_type-scatter_offp_impl.F90.fypp
+++ b/src/mpi/index_map_type-scatter_offp_impl.F90.fypp
@@ -10,11 +10,13 @@ implicit none
 contains
 
 #:set sum_types = [ ('i4', 'integer(i4)', 'MPI_INTEGER4'), &
+                  & ('i8', 'integer(i8)', 'MPI_INTEGER8'), &
                   & ('r4', 'real(r4)', 'MPI_REAL4'), &
                   & ('r8', 'real(r8)', 'MPI_REAL8'), &
                   & ('c4', 'complex(r4)', 'MPI_COMPLEX8'), &
                   & ('c8', 'complex(r8)', 'MPI_COMPLEX16') ]
 #:set minmax_types = [ ('i4', 'integer(i4)', 'MPI_INTEGER4'), &
+                     & ('i8', 'integer(i8)', 'MPI_INTEGER8'), &
                      & ('r4', 'real(r4)', 'MPI_REAL4'), &
                      & ('r8', 'real(r8)', 'MPI_REAL8') ]
 

--- a/src/mpi/index_map_type.F90.fypp
+++ b/src/mpi/index_map_type.F90.fypp
@@ -69,11 +69,13 @@ $:'(' + ':' + ',:' * (rank - 1) + ')'
 #:endfor
 #:endfor
 #:set scat_sum_types = [ ('i4', 'integer(i4)'), &
+                      & ('i8', 'integer(i8)'), &
                       & ('r4', 'real(r4)'), &
                       & ('r8', 'real(r8)'), &
                       & ('c4', 'complex(r4)'), &
                       & ('c8', 'complex(r8)') ]
 #:set scat_minmax_types = [ ('i4', 'integer(i4)'), &
+                         & ('i8', 'integer(i8)'), &
                          & ('r4', 'real(r4)'), &
                          & ('r8', 'real(r8)') ]
 #:for suffix, decl in scat_sum_types

--- a/test/scatter_test.F90
+++ b/test/scatter_test.F90
@@ -7,7 +7,7 @@
 
 program main
 
-  use,intrinsic :: iso_fortran_env, only: int32, real32, real64, output_unit
+  use,intrinsic :: iso_fortran_env, only: int32, int64, real32, real64, output_unit
   use index_map_type
 #ifndef USE_CAF
   use mpi
@@ -134,6 +134,12 @@ contains
       call write_result(all(array == output), 'test_sum_rank1_int32')
     end block
     block
+      integer(int64), allocatable :: array(:)
+      array = input
+      call imap%scatter_offp_sum(array)
+      call write_result(all(array == output), 'test_sum_rank1_int64')
+    end block
+    block
       real(real32), allocatable :: array(:)
       array = input
       call imap%scatter_offp_sum(array)
@@ -179,6 +185,12 @@ contains
       call write_result(all(array == output), 'test_min_rank1_int32')
     end block
     block
+      integer(int64), allocatable :: array(:)
+      array = input
+      call imap%scatter_offp_min(array)
+      call write_result(all(array == output), 'test_min_rank1_int64')
+    end block
+    block
       real(real32), allocatable :: array(:)
       array = input
       call imap%scatter_offp_min(array)
@@ -210,6 +222,12 @@ contains
       array = input
       call imap%scatter_offp_max(array)
       call write_result(all(array == output), 'test_max_rank1_int32')
+    end block
+    block
+      integer(int64), allocatable :: array(:)
+      array = input
+      call imap%scatter_offp_max(array)
+      call write_result(all(array == output), 'test_max_rank1_int64')
     end block
     block
       real(real32), allocatable :: array(:)


### PR DESCRIPTION
## Summary
- add int64 support to scatter_offp sum/min/max generators for MPI and CAF
- extend scatter tests to cover int64 sum/min/max cases
- validate the full MPI and CAF test suites with the Intel/MPICH toolchain

## Testing
- ml intel mpich && cmake -S . -B build-intel-mpi
- ml intel mpich && cmake --build build-intel-mpi -j
- ml intel mpich && ctest --test-dir build-intel-mpi --output-on-failure
- ml intel mpich && cmake -S . -B build-intel-caf -DUSE_CAF=ON
- ml intel mpich && cmake --build build-intel-caf -j
- ml intel mpich && ctest --test-dir build-intel-caf --output-on-failure